### PR TITLE
Add a check to silence an error when switching displays with xrandr.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -40,6 +40,7 @@ client.connect_signal("focus", function(c)
 
     gears.timer.weak_start_new(0.15, function()
         local client_under_mouse = mouse.current_client
+        if client_under_mouse == nil then return false end
         local should_stay = set_contains(stay_classes, client_under_mouse.class)
 
         if should_stay then return false end


### PR DESCRIPTION
Hi,

When I dock/undock my laptop to an external display, I cal xrandr then I restart awesome.
In that case, I had the following error in my awesome logs:
```
2023-09-28 19:22:39 E: awesome: Error during a protected call: /home/sathors/.config/awesome/awesomewm-micky/init.lua:43: attempt to index a nil value (local 'client_under_mouse')
stack traceback:
    /home/sathors/.config/awesome/awesomewm-micky/init.lua:43: in function </home/sathors/.config/awesome/awesomewm-micky/init.lua:41>
    (...tail calls...)
    [C]: in function 'xpcall'
    /usr/share/awesome/lib/gears/protected_call.lua:36: in function </usr/share/awesome/lib/gears/protected_call.lua:35>
    (...tail calls...)
    /usr/share/awesome/lib/gears/timer.lua:198: in local 'func'
    /usr/share/awesome/lib/gears/object.lua:148: in function 'gears.object.emit_signal'
    [C]: in function 'xpcall'
    /usr/share/awesome/lib/gears/protected_call.lua:36: in function </usr/share/awesome/lib/gears/protected_call.lua:35>
    (...tail calls...)
    /usr/share/awesome/lib/gears/timer.lua:92: in function </usr/share/awesome/lib/gears/timer.lua:91>
```

To fix the error in that case, I added a simple check in the code to bail out if `client_under_mouse` is nil.

Maybe it is not the best way to fix the problem, I'm not sure, because my knowledge of lua scripting and of the awesome API is limited.